### PR TITLE
refactor: Removed autoimport

### DIFF
--- a/packages/safelight/.gitignore
+++ b/packages/safelight/.gitignore
@@ -1,7 +1,5 @@
 # Generated dev files
 /stats.html
-/auto-imports.d.ts
-/components.d.ts
 /typed-router.d.ts
 
 # Generated items

--- a/packages/safelight/package.json
+++ b/packages/safelight/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "type": "module",
     "scripts": {
-        "dev": "pnpm generate-all && rm -f auto-imports.d.ts components.d.ts && vite",
+        "dev": "pnpm generate-all && vite",
         "generate-disclaimer": "cd ../../ && pnpm-licenses generate-disclaimer -o ./packages/safelight/src/generated/disclaimer.txt",
         "generate-license": "cd ../../ && pnpm-licenses list -o ./packages/safelight/src/generated/licenses.json",
         "generate-package-list": "tsx ./buildscripts/generatePackageList.ts",
@@ -62,9 +62,7 @@
         "ts-node-dev": "^2.0.0",
         "tsx": "^4.15.5",
         "typescript": "^5.4.5",
-        "unplugin-auto-import": "^0.17.5",
         "unplugin-turbo-console": "^1.8.6",
-        "unplugin-vue-components": "^0.27.0",
         "unplugin-vue-router": "^0.8.6",
         "vite": "^5.2.12",
         "vite-plugin-mkcert": "^1.17.5",

--- a/packages/safelight/src/App.vue
+++ b/packages/safelight/src/App.vue
@@ -4,6 +4,10 @@
 </template>
 
 <script setup lang="ts">
+import { useTitle } from '@vueuse/core';
+import { watchEffect } from 'vue';
+import { RouterView } from 'vue-router';
+import NotificationManager from './components/General/Notifications/NotificationManager.vue';
 import { router } from './main';
 
 const pageTitle = useTitle();

--- a/packages/safelight/src/components/Editor/CodeEditor/Monaco.vue
+++ b/packages/safelight/src/components/Editor/CodeEditor/Monaco.vue
@@ -10,9 +10,10 @@
 </template>
 
 <script setup lang="ts">
-import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
-import OneMonokai from './themes/OneMonokai-Monaco.json';
 import type { editor } from 'monaco-editor';
+import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import { onBeforeUnmount, onMounted, ref, shallowRef, watch } from 'vue';
+import OneMonokai from './themes/OneMonokai-Monaco.json';
 
 const vModel = defineModel<string>({
     default: '',

--- a/packages/safelight/src/components/Editor/Library/Library.vue
+++ b/packages/safelight/src/components/Editor/Library/Library.vue
@@ -192,13 +192,36 @@
 </template>
 
 <script setup lang="ts">
+import { CurrentProject } from '@/stores/currentProject';
+import {
+    PhImage,
+    PhMagnifyingGlass,
+    PhPlus,
+    PhSortAscending,
+    PhSortDescending,
+    PhSpeakerHigh,
+    PhSubtitles,
+    PhVideoCamera
+} from '@phosphor-icons/vue';
 import { ProjectFeatures } from '@safelight/shared/base/Project';
 import Media, { MediaType } from '@safelight/shared/Media/Media';
 import Timecode from '@safelight/shared/Timecode';
+import { useDropZone, useFileDialog, watchDebounced } from '@vueuse/core';
 import fuzzysearch from 'fuzzysearch';
 import MimeMatcher from 'mime-matcher';
+import Button from 'primevue/button';
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
+import DataView from 'primevue/dataview';
+import DataViewLayoutOptions from 'primevue/dataviewlayoutoptions';
+import Dropdown from 'primevue/dropdown';
 import InputGroup from 'primevue/inputgroup';
 import InputGroupAddon from 'primevue/inputgroupaddon';
+import InputText from 'primevue/inputtext';
+import Slider from 'primevue/slider';
+import Toolbar from 'primevue/toolbar';
+import { ref, shallowRef, watchEffect } from 'vue';
+import LibraryGridItem from './LibraryGridItem.vue';
 
 useDropZone(document.body, {
     onDrop(files) {

--- a/packages/safelight/src/components/Editor/Library/LibraryGridItem.vue
+++ b/packages/safelight/src/components/Editor/Library/LibraryGridItem.vue
@@ -117,12 +117,25 @@
     </OverlayPanel>
 </template>
 <script setup lang="ts">
+import { CurrentProject } from '@/stores/currentProject';
+import {
+    PhDotsThreeVertical,
+    PhImage,
+    PhSpeakerHigh,
+    PhSubtitles,
+    PhTrash,
+    PhVideoCamera
+} from '@phosphor-icons/vue';
 import { ProjectFeatures } from '@safelight/shared/base/Project';
 import type Media from '@safelight/shared/Media/Media';
 import { MediaType } from '@safelight/shared/Media/Media';
-import type Menu from 'primevue/menu';
+import Button from 'primevue/button';
+import Menu from 'primevue/menu';
 import type { MenuItem } from 'primevue/menuitem';
 import OverlayPanel from 'primevue/overlaypanel';
+import Skeleton from 'primevue/skeleton';
+import Toolbar from 'primevue/toolbar';
+import { computed, ref } from 'vue';
 
 const props = defineProps<{
     item: Media;

--- a/packages/safelight/src/components/Editor/Monitor/Monitor.vue
+++ b/packages/safelight/src/components/Editor/Monitor/Monitor.vue
@@ -5,4 +5,6 @@
     </div>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import PlaybackControls from '../Timeline/PlaybackControls.vue';
+</script>

--- a/packages/safelight/src/components/Editor/Timeline/PlaybackControls.vue
+++ b/packages/safelight/src/components/Editor/Timeline/PlaybackControls.vue
@@ -35,7 +35,12 @@
 </template>
 
 <script lang="ts" setup>
+import { CurrentProject } from '@/stores/currentProject';
+import { PhPause, PhPlay, PhSkipBack, PhSkipForward } from '@phosphor-icons/vue';
+import Button from 'primevue/button';
 import ButtonGroup from 'primevue/buttongroup';
+import { computed } from 'vue';
+import Timecode from './Timecode.vue';
 
 const { project } = CurrentProject;
 const timeline = computed(() =>

--- a/packages/safelight/src/components/Editor/Timeline/Timecode.vue
+++ b/packages/safelight/src/components/Editor/Timeline/Timecode.vue
@@ -15,8 +15,11 @@
 </template>
 
 <script setup lang="ts">
+import { CurrentProject } from '@/stores/currentProject';
 import Timecode from '@safelight/shared/Timecode';
-import type Inplace from 'primevue/inplace';
+import Inplace from 'primevue/inplace';
+import InputMask from 'primevue/inputmask';
+import { computed, ref } from 'vue';
 
 const timeline = CurrentProject.project.value!.timeline;
 const timecodeVal = computed(() =>

--- a/packages/safelight/src/components/Editor/Timeline/Timeline.vue
+++ b/packages/safelight/src/components/Editor/Timeline/Timeline.vue
@@ -9,10 +9,11 @@
 </template>
 
 <script setup lang="ts">
+import { CurrentProject } from '@/stores/currentProject';
 import Timecode from '@safelight/shared/Timecode';
 import { Timeline as SLTimeline, type TimelineItem } from '@safelight/timeline/source';
 import { v4 as uuidv4 } from 'uuid';
-import { reactive } from 'vue';
+import { computed, reactive } from 'vue';
 
 const ids = new Array(17).fill('').map(() => uuidv4());
 

--- a/packages/safelight/src/components/General/Notifications/Notification.vue
+++ b/packages/safelight/src/components/General/Notifications/Notification.vue
@@ -43,10 +43,14 @@
 </template>
 
 <script setup lang="ts">
+import { PhInfo, PhWarning, PhWarningCircle, PhX } from '@phosphor-icons/vue';
 import {
     NotificationService,
     type Notification
 } from '@safelight/shared/UI/Notifications/NotificationService';
+import Button from 'primevue/button';
+import Panel from 'primevue/panel';
+import { computed } from 'vue';
 
 const props = defineProps<{
     notif: Notification;

--- a/packages/safelight/src/components/General/Notifications/NotificationManager.vue
+++ b/packages/safelight/src/components/General/Notifications/NotificationManager.vue
@@ -13,6 +13,8 @@
 
 <script setup lang="ts">
 import { NotificationService } from '@safelight/shared/UI/Notifications/NotificationService';
+import { computed } from 'vue';
+import Notification from './Notification.vue';
 
 const firstNotif = computed(() =>
     Array.from(NotificationService.activeNotifications.values()).at(-1)

--- a/packages/safelight/src/components/InplaceRename.vue
+++ b/packages/safelight/src/components/InplaceRename.vue
@@ -17,7 +17,8 @@
 </template>
 
 <script lang="ts" setup>
-import type InputText from 'primevue/inputtext';
+import InputText from 'primevue/inputtext';
+import { ref } from 'vue';
 
 defineSlots<{
     default: [];

--- a/packages/safelight/src/components/Lazy.vue
+++ b/packages/safelight/src/components/Lazy.vue
@@ -1,4 +1,6 @@
 <script lang="ts" setup>
+import { nextTick, ref } from 'vue';
+
 const shouldRender = ref(false);
 nextTick(() => {
     shouldRender.value = true;

--- a/packages/safelight/src/components/Menu/ProjectList/ProjectList.vue
+++ b/packages/safelight/src/components/Menu/ProjectList/ProjectList.vue
@@ -37,9 +37,16 @@
 
 <script setup lang="ts">
 import InplaceRename from '@/components/InplaceRename.vue';
+import { CurrentProject } from '@/stores/currentProject';
+import { PhArrowsClockwise } from '@phosphor-icons/vue';
 import { Storage, type StoredProject } from '@safelight/shared/base/Storage';
 import { DateTime } from 'luxon';
+import Button from 'primevue/button';
+import Column from 'primevue/column';
+import DataTable from 'primevue/datatable';
 import type { MenuItem } from 'primevue/menuitem';
+import SplitButton from 'primevue/splitbutton';
+import { onMounted, ref } from 'vue';
 
 const projectTypes: MenuItem[] = [
     {

--- a/packages/safelight/src/components/Panels/LoadingPanel.vue
+++ b/packages/safelight/src/components/Panels/LoadingPanel.vue
@@ -3,3 +3,7 @@
         <PhCircleNotch class="animate-spin" aria-label="Loading" size="48" />
     </div>
 </template>
+
+<script setup lang="ts">
+import { PhCircleNotch } from '@phosphor-icons/vue';
+</script>

--- a/packages/safelight/src/components/Panels/PanelContainer.vue
+++ b/packages/safelight/src/components/Panels/PanelContainer.vue
@@ -18,7 +18,10 @@
 </template>
 
 <script setup lang="ts">
+import Splitter from 'primevue/splitter';
+import SplitterPanel from 'primevue/splitterpanel';
 import type { PanelSplitConfig } from './injection';
+import PanelGroup from './PanelGroup.vue';
 
 defineProps<{
     config: PanelSplitConfig;

--- a/packages/safelight/src/components/Panels/PanelGroup.vue
+++ b/packages/safelight/src/components/Panels/PanelGroup.vue
@@ -76,12 +76,26 @@
 </template>
 
 <script setup lang="ts">
+import { PhPlus, PhX } from '@phosphor-icons/vue';
 import PanelManager from '@safelight/shared/UI/Panels/PanelManager';
-import { createStaticVNode, createTextVNode, type StyleValue } from 'vue';
+import { watchImmediate } from '@vueuse/core';
+import Button from 'primevue/button';
+import Menu from 'primevue/menu';
+import type { MenuItem } from 'primevue/menuitem';
+import OverlayPanel from 'primevue/overlaypanel';
+import TabMenu from 'primevue/tabmenu';
+import {
+    computed,
+    createStaticVNode,
+    createTextVNode,
+    defineAsyncComponent,
+    ref,
+    shallowRef,
+    type Component,
+    type StyleValue
+} from 'vue';
 import { type Panel, type PanelGroupConfig } from './injection';
 import LoadingPanel from './LoadingPanel.vue';
-import type OverlayPanel from 'primevue/overlaypanel';
-import type { MenuItem } from 'primevue/menuitem';
 
 const props = defineProps<{
     config: PanelGroupConfig;
@@ -90,14 +104,14 @@ const props = defineProps<{
 
 const activeIndex = ref(0);
 
-const allTabs = computed<Panel[]>(() => {
+const allTabs = computed<MenuItem[]>(() => {
     const panelGroup = props.config;
     if (!panelGroup) return [];
 
     return panelGroup.panels
         .sort((p1, p2) => p1.order - p2.order)
         .map(({ panelId }) => PanelManager.allPanels.get(panelId))
-        .filter((p) => !!p);
+        .filter((p) => !!p) as unknown as MenuItem[];
 });
 
 const activeTab = computed(() => {

--- a/packages/safelight/src/stores/currentProject.ts
+++ b/packages/safelight/src/stores/currentProject.ts
@@ -3,6 +3,7 @@ import type BaseProject from '@safelight/shared/base/Project';
 import { ProjectFeatures, type ProjectType } from '@safelight/shared/base/Project';
 import BaseStorageController, { Storage, type StoredProject } from '@safelight/shared/base/Storage';
 import { DateTime } from 'luxon';
+import { ref, shallowRef } from 'vue';
 
 export class CurrentProject {
     // see #14 for why

--- a/packages/safelight/src/stores/useEditor.ts
+++ b/packages/safelight/src/stores/useEditor.ts
@@ -2,6 +2,7 @@ import type { PanelViewConfig } from '@/components/Panels/injection';
 import { PhFilmStrip, PhFolders, PhFrameCorners } from '@phosphor-icons/vue';
 import PanelManager from '@safelight/shared/UI/Panels/PanelManager';
 import { defineStore } from 'pinia';
+import { markRaw, reactive } from 'vue';
 
 export const useEditor = defineStore('Editor', () => {
     const activePanels = reactive<PanelViewConfig>([

--- a/packages/safelight/src/stores/useProject.ts
+++ b/packages/safelight/src/stores/useProject.ts
@@ -1,3 +1,6 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+
 export const useProject = defineStore('Project', () => {
     const cursor = ref(0);
 

--- a/packages/safelight/src/views/Editor/Editor.vue
+++ b/packages/safelight/src/views/Editor/Editor.vue
@@ -33,11 +33,19 @@
 </template>
 
 <script setup lang="ts">
+import InplaceRename from '@/components/InplaceRename.vue';
+import PanelContainer from '@/components/Panels/PanelContainer.vue';
 import { router } from '@/main';
+import { CurrentProject } from '@/stores/currentProject';
+import { useEditor } from '@/stores/useEditor';
+import { useProject } from '@/stores/useProject';
 import { PhFile } from '@phosphor-icons/vue';
 import ConfirmDialog from 'primevue/confirmdialog';
+import Menubar from 'primevue/menubar';
 import type { MenuItem } from 'primevue/menuitem';
+import Toolbar from 'primevue/toolbar';
 import { useConfirm } from 'primevue/useconfirm';
+import { onBeforeUnmount, onMounted, watch } from 'vue';
 
 const project = useProject();
 const editor = useEditor();

--- a/packages/safelight/src/views/dev/CodeEditor.vue
+++ b/packages/safelight/src/views/dev/CodeEditor.vue
@@ -1,9 +1,11 @@
 <template>
-    <SLButton to="/dev/">
-        <PhArrowLeft />
-    </SLButton>
+    <Button to="/dev/">
+        <template #icon>
+            <PhArrowLeft />
+        </template>
+    </Button>
     <div>
-        <SLButton
+        <Button
             @click="
                 tabs.push({
                     title: uuidv4() + '.ts',
@@ -11,17 +13,21 @@
                 })
             "
         >
-            <PhPlus />
-        </SLButton>
+            <template #icon>
+                <PhPlus />
+            </template>
+        </Button>
     </div>
 
     <br />
 
     <div v-for="(tab, index) in tabs" :key="index">
         <input v-model="tab.title" type="text" />
-        <SLButton v-if="index > 0" @click="tabs.splice(index, 1)">
-            <PhTrash />
-        </SLButton>
+        <Button v-if="index > 0" @click="tabs.splice(index, 1)">
+            <template #icon>
+                <PhTrash />
+            </template>
+        </Button>
         <Lazy>
             <Monaco v-if="showEditors" v-model="tab.content" height="300"></Monaco>
         </Lazy>
@@ -29,12 +35,12 @@
     </div>
 
     <div>
-        <SLButton @click="compile">
+        <Button @click="compile">
             <template #icon>
                 <PhWall></PhWall>
             </template>
             Compile
-        </SLButton>
+        </Button>
         <Lazy>
             <Monaco v-if="showEditors" v-model="result"></Monaco>
         </Lazy>
@@ -42,8 +48,12 @@
 </template>
 
 <script setup lang="ts">
+import Monaco from '@/components/Editor/CodeEditor/Monaco.vue';
+import Lazy from '@/components/Lazy.vue';
 import { PhArrowLeft, PhPlus, PhTrash, PhWall } from '@phosphor-icons/vue';
+import Button from 'primevue/button';
 import { v4 as uuidv4 } from 'uuid';
+import { onMounted, ref } from 'vue';
 
 const showEditors = ref(false);
 

--- a/packages/safelight/src/views/dev/Packages.vue
+++ b/packages/safelight/src/views/dev/Packages.vue
@@ -143,9 +143,18 @@
 </template>
 
 <script setup lang="ts">
-import { PhArrowLeft, PhArrowSquareOut, PhGitBranch } from '@phosphor-icons/vue';
+import { PhArrowLeft, PhArrowSquareOut, PhGitBranch, PhHouse } from '@phosphor-icons/vue';
+import { useDebounce, useFetch } from '@vueuse/core';
+import Button from 'primevue/button';
+import Card from 'primevue/card';
+import DataView from 'primevue/dataview';
+import Skeleton from 'primevue/skeleton';
+import TabPanel from 'primevue/tabpanel';
+import TabView from 'primevue/tabview';
 import type { Dependency, DependencyWithName, Packages } from 'types/packages';
+import { onMounted, reactive, ref, watch } from 'vue';
 import VueMarkdown from 'vue-markdown-render';
+import { RouterLink } from 'vue-router/auto';
 
 const showDisclaimer = ref(false);
 const showDisclaimerThrottle = useDebounce(showDisclaimer, 1000);

--- a/packages/safelight/src/views/dev/UI.vue
+++ b/packages/safelight/src/views/dev/UI.vue
@@ -2,7 +2,9 @@
 <template>
     <RouterLink to="/dev/">
         <Button style="margin: 0.5rem" alt="To dev pages overview">
-            <PhArrowLeft />
+            <template #icon>
+                <PhArrowLeft />
+            </template>
         </Button>
     </RouterLink>
 
@@ -36,8 +38,11 @@
 
 <script setup lang="ts">
 import Button from 'primevue/button';
+import Card from 'primevue/card';
 import Listbox from 'primevue/listbox';
+import Slider from 'primevue/slider';
 import { v4 as uuidv4 } from 'uuid';
+import { onMounted, ref, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 
 const timeline1 = ref();

--- a/packages/safelight/src/views/dev/dev.vue
+++ b/packages/safelight/src/views/dev/dev.vue
@@ -15,9 +15,9 @@
                 :key="route.path"
             >
                 <RouterLink :to="route.path" class="mb-2 block">
-                    <Button>{{
-                        (route.name?.toString() ?? route.path).replace('/dev/', '')
-                    }}</Button>
+                    <Button>
+                        {{ (route.name?.toString() ?? route.path).replace('/dev/', '') }}
+                    </Button>
                 </RouterLink>
             </template>
         </template>
@@ -25,6 +25,8 @@
 </template>
 
 <script setup lang="ts">
+import Button from 'primevue/button';
+import Card from 'primevue/card';
 import { RouterLink } from 'vue-router';
 </script>
 

--- a/packages/safelight/src/views/dev/devTimeline.vue
+++ b/packages/safelight/src/views/dev/devTimeline.vue
@@ -20,9 +20,14 @@
 </template>
 
 <script lang="ts" setup>
+import { PhArrowLeft } from '@phosphor-icons/vue';
 import type { TimelineItem } from '@safelight/timeline/source';
 import { Timeline } from '@safelight/timeline/source';
+import Button from 'primevue/button';
+import Card from 'primevue/card';
 import { v4 as uuidv4 } from 'uuid';
+import { reactive, ref } from 'vue';
+import { RouterLink } from 'vue-router/auto';
 
 const invertScrollAxes = ref(true);
 

--- a/packages/safelight/src/views/index.vue
+++ b/packages/safelight/src/views/index.vue
@@ -4,6 +4,7 @@
     <RouterLink to="/editor"> <Button>To Editor</Button> </RouterLink>
 </template>
 <script setup lang="ts">
+import Button from 'primevue/button';
 import { RouterLink } from 'vue-router';
 </script>
 

--- a/packages/safelight/src/views/projects.vue
+++ b/packages/safelight/src/views/projects.vue
@@ -6,4 +6,7 @@
     </Card>
 </template>
 
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import ProjectList from '@/components/Menu/ProjectList/ProjectList.vue';
+import Card from 'primevue/card';
+</script>

--- a/packages/safelight/vite.config.ts
+++ b/packages/safelight/vite.config.ts
@@ -1,48 +1,12 @@
 import { fileURLToPath, URL } from 'node:url';
 
 import vue from '@vitejs/plugin-vue';
-import path, { resolve } from 'node:path';
+import path from 'node:path';
 import { visualizer } from 'rollup-plugin-visualizer';
-import AutoImport from 'unplugin-auto-import/vite';
 import TurboConsole from 'unplugin-turbo-console/vite';
-import { ComponentResolverObject } from 'unplugin-vue-components';
-import { PrimeVueResolver } from 'unplugin-vue-components/resolvers';
-import Components from 'unplugin-vue-components/vite';
 import VueRouter from 'unplugin-vue-router/vite';
 import { defineConfig } from 'vite';
 import mkcert from 'vite-plugin-mkcert';
-
-const PhosphorResolver: ComponentResolverObject = {
-    type: 'component',
-    async resolve(name) {
-        if (name.startsWith('Ph')) {
-            return resolve(
-                __dirname,
-                `./node_modules/@phosphor-icons/vue/dist/icons/${name}.vue.mjs`
-            ).replace(/\\/g, '/');
-        }
-    }
-};
-
-const vueuseRxjsAutoImport = {
-    from: '@vueuse/rxjs',
-    imports: [
-        'OnCleanup',
-        'UseExtractedObservableOptions',
-        'UseObservableOptions',
-        'UseSubjectOptions',
-        'WatchExtractedObservableCallback',
-        'WatchExtractedObservableOptions',
-        'from',
-        'fromEvent',
-        'toObserver',
-        'useExtractedObservable',
-        'useObservable',
-        'useSubject',
-        'useSubscription',
-        'watchExtractedObservable'
-    ]
-};
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -56,22 +20,6 @@ export default defineConfig({
             }
         }),
         vue(),
-        Components({
-            dirs: ['src/components', 'src/@core'],
-            resolvers: [PrimeVueResolver({ importIcons: false }), PhosphorResolver]
-        }),
-        AutoImport({
-            imports: [
-                'vue',
-                'vue-router',
-                '@vueuse/core',
-                '@vueuse/math',
-                'pinia',
-                vueuseRxjsAutoImport
-            ],
-            dirs: ['./src/stores', './src/controllers/**'],
-            vueTemplate: true
-        }),
         TurboConsole(),
         mkcert(),
         visualizer()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -268,15 +268,9 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.4.5
-      unplugin-auto-import:
-        specifier: ^0.17.5
-        version: 0.17.6(@vueuse/core@10.10.0)
       unplugin-turbo-console:
         specifier: ^1.8.6
         version: 1.8.6(vite@5.2.13)(vue@3.4.29)
-      unplugin-vue-components:
-        specifier: ^0.27.0
-        version: 0.27.0(vue@3.4.29)
       unplugin-vue-router:
         specifier: ^0.8.6
         version: 0.8.8(vue-router@4.3.2)(vue@3.4.29)
@@ -414,10 +408,6 @@ packages:
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
-    dev: true
-
-  /@antfu/utils@0.7.8:
-    resolution: {integrity: sha512-rWQkqXRESdjXtc+7NRfK9lASQjpXJu1ayp7qi1d23zZorY+wBHVLHHoVcMsEnkqEBWTFqbztO7/QdJFzyEcLTg==}
     dev: true
 
   /@babel/code-frame@7.24.7:
@@ -1631,6 +1621,7 @@ packages:
 
   /@types/web-bluetooth@0.0.20:
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
+    dev: false
 
   /@typescript-eslint/eslint-plugin@7.12.0(@typescript-eslint/parser@7.12.0)(eslint@8.57.0)(typescript@5.4.5):
     resolution: {integrity: sha512-7F91fcbuDf/d3S8o21+r3ZncGIke/+eWk0EpO21LXhDfLahriZF9CGj4fbAetEjlaBdjdSm9a6VeXbpbT6Z40Q==}
@@ -1985,7 +1976,7 @@ packages:
       pathe: 1.1.2
       picocolors: 1.0.1
       sirv: 2.0.4
-      vitest: 1.6.0(@types/node@20.14.2)(@vitest/browser@1.6.0)(@vitest/ui@1.6.0)
+      vitest: 1.6.0(@vitest/browser@1.6.0)(@vitest/ui@1.6.0)
     dev: true
 
   /@vitest/utils@1.6.0:
@@ -2182,6 +2173,7 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+    dev: false
 
   /@vueuse/core@10.11.0(vue@3.4.29):
     resolution: {integrity: sha512-x3sD4Mkm7PJ+pcq3HX8PLPBadXCAlSDR/waK87dz0gQE+qJnaaFhc/dZVfJz+IUYzTMVGum2QlR7ImiJQN4s6g==}
@@ -2274,6 +2266,7 @@ packages:
 
   /@vueuse/metadata@10.10.0:
     resolution: {integrity: sha512-UNAo2sTCAW5ge6OErPEHb5z7NEAg3XcO9Cj7OK45aZXfLLH1QkexDcZD77HBi5zvEiLOm1An+p/4b5K3Worpug==}
+    dev: false
 
   /@vueuse/metadata@10.11.0:
     resolution: {integrity: sha512-kQX7l6l8dVWNqlqyN3ePW3KmjCQO3ZMgXuBMddIu83CmucrsBfXlH+JoviYyRBws/yLTQO8g3Pbw+bdIoVm4oQ==}
@@ -2316,6 +2309,7 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+    dev: false
 
   /@vueuse/shared@10.11.0(vue@3.4.29):
     resolution: {integrity: sha512-fyNoIXEq3PfX1L3NkNhtVQUSRtqYwJtJg+Bp9rIzculIZWHTkKSysujrOk2J+NrRulLTQH9+3gGSfYLWSEWU1A==}
@@ -2993,11 +2987,6 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-    dev: true
-
-  /escape-string-regexp@5.0.0:
-    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
-    engines: {node: '>=12'}
     dev: true
 
   /eslint-config-prettier@9.1.0(eslint@8.57.0):
@@ -5164,57 +5153,12 @@ packages:
       pathe: 1.1.2
     dev: true
 
-  /unimport@3.7.2:
-    resolution: {integrity: sha512-91mxcZTadgXyj3lFWmrGT8GyoRHWuE5fqPOjg5RVtF6vj+OfM5G6WCzXjuYtSgELE5ggB34RY4oiCSEP8I3AHw==}
-    dependencies:
-      '@rollup/pluginutils': 5.1.0
-      acorn: 8.11.3
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.1.1
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.10.1
-    transitivePeerDependencies:
-      - rollup
-    dev: true
-
   /universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
-    dev: true
-
-  /unplugin-auto-import@0.17.6(@vueuse/core@10.10.0):
-    resolution: {integrity: sha512-dmX0Pex5DzMzVuALkexboOZvh51fL/BD6aoPO7qHoTYGlQp0GRKsREv2KMF1lzYI9SXKQiRxAjwzbQnrFFNydQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@nuxt/kit': ^3.2.2
-      '@vueuse/core': '*'
-    peerDependenciesMeta:
-      '@nuxt/kit':
-        optional: true
-      '@vueuse/core':
-        optional: true
-    dependencies:
-      '@antfu/utils': 0.7.8
-      '@rollup/pluginutils': 5.1.0
-      '@vueuse/core': 10.10.0(vue@3.4.29)
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      minimatch: 9.0.4
-      unimport: 3.7.2
-      unplugin: 1.10.1
-    transitivePeerDependencies:
-      - rollup
     dev: true
 
   /unplugin-turbo-console@1.8.6(vite@5.2.13)(vue@3.4.29):
@@ -5258,35 +5202,6 @@ packages:
       vue: 3.4.29(typescript@5.4.5)
     transitivePeerDependencies:
       - uWebSockets.js
-    dev: true
-
-  /unplugin-vue-components@0.27.0(vue@3.4.29):
-    resolution: {integrity: sha512-77eTEy23sQ0UpzGWnZ9I2mY3cnmXwklz4ITcn3JfxjCoX643ghImkiZ4nFm58sxbdVcc4Fo/o4LIoFnlqEqsSg==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@babel/parser': ^7.15.8
-      '@nuxt/kit': ^3.2.2
-      vue: 2 || 3
-    peerDependenciesMeta:
-      '@babel/parser':
-        optional: true
-      '@nuxt/kit':
-        optional: true
-    dependencies:
-      '@antfu/utils': 0.7.8
-      '@rollup/pluginutils': 5.1.0
-      chokidar: 3.6.0
-      debug: 4.3.5
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.10
-      minimatch: 9.0.4
-      resolve: 1.22.8
-      unplugin: 1.10.1
-      vue: 3.4.29(typescript@5.4.5)
-    transitivePeerDependencies:
-      - rollup
-      - supports-color
     dev: true
 
   /unplugin-vue-router@0.8.8(vue-router@4.3.2)(vue@3.4.29):
@@ -5686,6 +5601,7 @@ packages:
         optional: true
     dependencies:
       vue: 3.4.29(typescript@5.4.5)
+    dev: false
 
   /vue-eslint-parser@9.4.3(eslint@8.57.0):
     resolution: {integrity: sha512-2rYRLWlIpaiN8xbPiDyXZXRgLGOtWxERV7ND5fFAv5qo1D2N9Fu9MNajBNc6o13lZ+24DAWCkQCvj4klgmcITg==}


### PR DESCRIPTION
Removed component and module autoimport

Components like phosphor icons, vue built-in components and components inside safelight need to be manually imported